### PR TITLE
Feature/h2 testing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-data-rest'
 	
-	compile ('com.h2database:h2')
+	
 	compile("org.springframework.boot:spring-boot-starter")
 	compile("org.springframework.boot:spring-boot-starter-web")
 	compile("org.springframework.boot:spring-boot-starter-data-jpa")
@@ -42,6 +42,8 @@ dependencies {
 	compile("org.springframework.cloud:spring-cloud-stream-binder-kafka-streams")
 	
 	runtime 'org.postgresql:postgresql:42.2.10'
+	
+	testCompile ('com.h2database:h2')
 	
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.postgresql:postgresql'

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-data-rest'
 	
+	compile ('com.h2database:h2')
 	compile("org.springframework.boot:spring-boot-starter")
 	compile("org.springframework.boot:spring-boot-starter-web")
 	compile("org.springframework.boot:spring-boot-starter-data-jpa")

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,17 +1,6 @@
-spring.main.banner-mode=off
-logging.level.org.springframework=ERROR
-logging.level.root=INFO
-
-spring.jpa.show-sql=true
-#Do not use this in production
 spring.jpa.hibernate.ddl-auto=update
 spring.datasource.driverClassName=org.h2.Driver
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 
-spring.datasource.initialization-mode=always
 spring.datasource.platform=h2
 spring.datasource.url=jdbc:h2:mem:testdb;Mode=PostgreSQL
-spring.datasource.username=${PG_DB_USERNAME:postgres}
-spring.datasource.password=${PG_DB_PASSWORD:postgres}
-
-spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,19 +1,17 @@
-#spring.main.banner-mode=off
+spring.main.banner-mode=off
 logging.level.org.springframework=ERROR
 logging.level.root=INFO
 
 spring.jpa.show-sql=true
 #Do not use this in production
-spring.jpa.hibernate.ddl-auto=create-drop
-spring.cloud.stream.bindings.input.destination=mySource
-spring.datasource.driverClassName=org.postgresql.Driver
-spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.hibernate.ddl-auto=update
+spring.datasource.driverClassName=org.h2.Driver
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 
 spring.datasource.initialization-mode=always
-spring.datasource.platform=postgres
-spring.datasource.url=jdbc:postgresql://${PG_DB_ADDRESS:localhost:5432}/${PG_DB_NAME:saraswati-test}
+spring.datasource.platform=h2
+spring.datasource.url=jdbc:h2:mem:testdb;Mode=PostgreSQL
 spring.datasource.username=${PG_DB_USERNAME:postgres}
 spring.datasource.password=${PG_DB_PASSWORD:postgres}
 
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
-


### PR DESCRIPTION
###Problem###

The testing framework was more of an integration test than a unit-test, as it required a connection to an external Database. Additionally the structure for running the tests on the application required a good deal of setup, and often required the database to be re-created with almost any model change.

###Solution###

The application.properties in `src/test/resources` have been modified to use H2 in Postgres compatibility mode rather than a live PSQL database. This means the application itself will run the tests against an internally consistent database, and will recreate the database for each test. Additionally, this makes it far easier to run the tests for the application.

###Test###

Checkout the appropriate branch
Use a shell to run `gradle test` from the root directory.